### PR TITLE
feat: Support Ollama and LM Studio backends (Resolves #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,39 @@ Tool calls are parsed three ways for broad model compatibility:
 
 ## Setup
 
+### Option 1: llama.cpp (Recommended)
 ```bash
-# Build llama.cpp (or use Ollama, vLLM, anything OpenAI-compatible)
+# Build llama.cpp
 git clone --depth 1 https://github.com/ggml-org/llama.cpp.git
 cd llama.cpp && mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release && make -j$(nproc)
 
-# Get a model that does tool use
-mkdir -p ~/models
-curl -L -o ~/models/qwen2.5-3b-instruct-q4.gguf \
-  "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/main/qwen2.5-3b-instruct-q4_k_m.gguf"
-
 # Start the server
 ./bin/llama-server -m ~/models/qwen2.5-3b-instruct-q4.gguf -t 12 -c 4096
+```
 
-# Run the agent
+### Option 2: Ollama
+Ollama exposes an OpenAI-compatible endpoint. TrashClaw will automatically detect it and append `/v1`.
+```bash
+# Start an Ollama model that supports tools
+ollama run qwen2.5:3b
+
+# Run TrashClaw pointing to Ollama
+TRASHCLAW_URL=http://localhost:11434 python3 trashclaw.py
+```
+
+### Option 3: LM Studio
+LM Studio provides an easy GUI for running local models.
+1. Download a model that supports tools (e.g. Qwen 2.5 3B Instruct) in LM Studio.
+2. Start the Local Server in the LM Studio sidebar.
+3. Note the server URL (usually `http://localhost:1234/v1`).
+```bash
+TRASHCLAW_URL=http://localhost:1234/v1 python3 trashclaw.py
+```
+
+### Run the agent
+```bash
+# Once any of the above servers are running:
 python3 trashclaw.py
 ```
 

--- a/trashclaw.py
+++ b/trashclaw.py
@@ -839,20 +839,52 @@ def main():
 
     banner()
 
-    # Check server
-    try:
-        req = urllib.request.Request(f"{LLAMA_URL}/health")
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            health = json.loads(resp.read().decode("utf-8"))
-        if health.get("status") != "ok":
-            print(f"\033[33m[WARN]\033[0m Server status: {health}")
-    except Exception:
-        print(f"\033[31m[ERROR]\033[0m Cannot reach llama-server at {LLAMA_URL}")
-        print("  Start it with:")
-        print("  llama-server -m <model.gguf> --host 0.0.0.0 --port 8080 -t 10 -c 4096")
-        sys.exit(1)
+    # Backend Detection
+    backend = "Unknown"
+    base_url = LLAMA_URL.rstrip("/")
+    if base_url.endswith("/v1"):
+        base_url = base_url[:-3]
 
-    print(f"  \033[32mConnected to {LLAMA_URL}\033[0m\n")
+    # 1. Try LM Studio (/v1/models)
+    try:
+        req = urllib.request.Request(f"{base_url}/v1/models")
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            if "data" in data:
+                backend = "LM Studio"
+                globals()["LLAMA_URL"] = f"{base_url}/v1"
+    except Exception:
+        pass
+
+    # 2. Try Ollama (/api/tags)
+    if backend == "Unknown":
+        try:
+            req = urllib.request.Request(f"{base_url}/api/tags")
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+                if "models" in data:
+                    backend = "Ollama"
+                    globals()["LLAMA_URL"] = f"{base_url}/v1"
+        except Exception:
+            pass
+
+    # 3. Try llama.cpp (/health)
+    if backend == "Unknown":
+        try:
+            req = urllib.request.Request(f"{base_url}/health")
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                health = json.loads(resp.read().decode("utf-8"))
+            if health.get("status") in ("ok", "error", "loading"):
+                backend = "llama.cpp"
+                # llama.cpp also typically exposes /v1 for OpenAI compat
+                globals()["LLAMA_URL"] = base_url
+        except Exception:
+            pass
+
+    if backend == "Unknown":
+        print(f"\033[33m[WARN]\033[0m Cannot definitively detect backend at {LLAMA_URL}. Assuming OpenAI-compatible.")
+    else:
+        print(f"  \033[32mConnected to {backend} at {LLAMA_URL}\033[0m\n")
 
     while True:
         try:


### PR DESCRIPTION
This PR adds automatic backend detection for Ollama, LM Studio, and llama-server.

- On startup, `trashclaw` probes `/v1/models`, `/api/tags`, and `/health` to identify the backend.
- It normalizes the base URL automatically to point to the `/v1` OpenAI compatibility endpoints.
- Setup instructions for Ollama and LM Studio have been added to the README.

Resolves #6.