### PR TITLE
docs: link Windows compatibility guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ python trashclaw.py
 
 Without `pyreadline3`, TrashClaw will still work but command history (up/down arrows) won't be available.
 
+For a full Windows setup and compatibility checklist, see [WINDOWS_COMPATIBILITY.md](WINDOWS_COMPATIBILITY.md).
+
 ### Option 1: llama.cpp (Recommended)
 ```bash
 # Build llama.cpp


### PR DESCRIPTION
## Summary
- add a direct README link to  in the Windows installation section
- make the Windows setup path easier to discover for first-time users

## Why
The repo already has a detailed Windows compatibility guide, but the main README did not point Windows users to it. This small docs improvement makes the existing guidance easier to find.