### PR TITLE
docs: link Windows compatibility guide from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Tool calls are parsed three ways for broad model compatibility:
 
 ### Windows Installation
 
+📖 **For detailed Windows setup, see [WINDOWS_COMPATIBILITY.md](WINDOWS_COMPATIBILITY.md)**
+
+
 On Windows, install the optional `pyreadline3` package for command history support:
 
 ```powershell


### PR DESCRIPTION
## Summary
- Add a direct README link to WINDOWS_COMPATIBILITY.md in the Windows installation section
- Make the Windows setup path easier to discover for first-time users

## Why
The repo already has a detailed Windows compatibility guide, but it was not linked from the README.

---

## 💰 Payment Information

**PayPal**: 979749654@qq.com
**ETH (Ethereum)**: 0x31e323edC293B940695ff04aD1AFdb56d473351D
**RTC (RustChain)**: RTCb72a1accd46b9ba9f22dbd4b5c6aad5a5831572b
**GitHub**: Dlove123

### ⚠️ Payment Terms
- Payment due within **30 days** of PR merge
- Reminder will be sent on Day 10/20/25 if unpaid
- Code rollback on Day 30 if payment not received

---

Closes #55