### PR TITLE
docs: add link to OpenClaw repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A general-purpose local agent that runs on anything — including a 2013 Mac Pro that looks like a trash can. No cloud, no API keys, no dependencies beyond Python 3.7 and a llama-server.
 
-Think OpenClaw but it runs on your old hardware.
+Think [OpenClaw](https://github.com/openclaw/openclaw) but it runs on your old hardware.
 
 ## What it does
 


### PR DESCRIPTION
This PR adds a helpful link to the OpenClaw repository mentioned in the README. Claiming bounty #2178 from rustchain-bounties.