### PR TITLE
docs: Add CONTRIBUTORS.md file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,17 @@
+﻿# Contributors
+
+Thank you to all the amazing people who have contributed to TrashClaw!
+
+| Name | GitHub | Contributions |
+|------|--------|---------------|
+| Scott | [@Scottcjn](https://github.com/Scottcjn) | Core development, architecture |
+| MingYu5 | [@MingYu5](https://github.com/MingYu5) | Sessions, git tools concept |
+| newffnow | [@newffnow](https://github.com/newffnow) | Windows support, documentation |
+| allornothingai | [@allornothingai](https://github.com/allornothingai) | Model matrix |
+| Dlove123 | [@Dlove123](https://github.com/Dlove123) | Documentation |
+| botyhacker6 | [@botyhacker6](https://github.com/botyhacker6) | Documentation |
+| MrJHSN | [@MrJHSN](https://github.com/MrJHSN) | Multi-backend PR |
+| ryan-the-zilla | [@ryan-the-zilla](https://github.com/ryan-the-zilla) | CONTRIBUTING.md |
+| Zby-coding | [@Zby-coding](https://github.com/Zby-coding) | CONTRIBUTORS.md |
+
+This project follows the [all-contributors](https://allcontributors.org) specification.


### PR DESCRIPTION
Lists all contributors to TrashClaw with their GitHub usernames and contributions.

Includes: Scottcjn (core), MingYu5 (sessions, git tools concept), newffnow (Windows, docs), allornothingai (model matrix), Dlove123 (docs), botyhacker6 (docs), MrJHSN (multi-backend PR), ryan-the-zilla (CONTRIBUTING.md)

Closes #68
Bounty: 2 RTC