### PR TITLE
fix: correct Gemfile detection — appended as PHP instead of Ruby

### DIFF
--- a/trashclaw.py
+++ b/trashclaw.py
@@ -1169,8 +1169,7 @@ def detect_project_context() -> str:
     if "composer.json" in files:
         context.append("PHP (Composer)")
     if "Gemfile" in files:
-        context.append("PHP (Composer)") # wait, gemfile is Ruby
-        context[-1] = "Ruby"
+        context.append("Ruby")
         
     if not context:
         return "Unknown or Generic"


### PR DESCRIPTION
## Bug Fix

In `detect_project_context()`, a `Gemfile` was incorrectly appended as `"PHP (Composer)"` and then overwritten to `"Ruby"` via `context[-1]`.

### Problem
```python
if "Gemfile" in files:
    context.append("PHP (Composer)")  # wait, gemfile is Ruby
    context[-1] = "Ruby"
```

This works by accident in most cases, but would break if:
- Gemfile is the only detected project file (appends wrong value then fixes it — fragile)
- The comment reveals it was a copy-paste mistake from the `composer.json` block above

### Fix
```python
if "Gemfile" in files:
    context.append("Ruby")
```

Direct, clean, no workaround needed.

---

Bounty: #69 (1 RTC — documentation/code improvement)