### PR TITLE
add add /pipe command to save last response to file

### DIFF
--- a/commands/pipe.py
+++ b/commands/pipe.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+
+import os
+from datetime import datetime
+from commands.base import BaseCommand
+
+
+class PipeCommand(BaseCommand):
+    def __init__(self, history):
+        super().__init__()
+        self.history = history
+
+    def execute(self, args):
+        """Save last assistant response to file"""
+        if not self.history:
+            print("No conversation history available to save.")
+            return
+
+        # Find the last assistant message
+        last_assistant_msg = None
+        for msg in reversed(self.history):
+            if msg.get('role') == 'assistant':
+                last_assistant_msg = msg.get('content', '')
+                break
+
+        if not last_assistant_msg:
+            print("No assistant response found in history.")
+            return
+
+        # Determine filename
+        if args:
+            filename = ' '.join(args)
+        else:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            filename = f"response_{timestamp}.txt"
+
+        try:
+            # Write to file
+            with open(filename, 'w', encoding='utf-8') as f:
+                f.write(last_assistant_msg)
+
+            # Get file size
+            file_size = os.path.getsize(filename)
+            abs_path = os.path.abspath(filename)
+
+            print(f"Saved to: {abs_path}")
+            print(f"Size: {file_size} bytes")
+
+        except Exception as e:
+            print(f"Error saving file: {e}")


### PR DESCRIPTION
Create a new pipe command handler that retrieves the last assistant message from HISTORY and saves it to a file with proper error handling and user feedback.

resolves #Scottcjn/trashclaw#66

- `commands/pipe.py`

**testing notes:** ran locally, verified it integrates correctly with the existing code. no regressions found.

**rtc wallet:** `RTC2fe3c33c77666ff76a1cd0999fd4466ee81250ff`
- eth: `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- base: `0x010A63e7Ee6E4925d2a71Bc93EA5374c9678869b`
- sol: `HZV6YPdTeJPjPujWjzsFLLKja91K2Ze78XeY8MeFhfK8`
- ton: `UQC3yiapHm9Y7o06eFJq_emW_BjTUnPMYuqeAacTJw_uXiQe`

**additional testing:** Tested by having an assistant response in history, then using `/pipe test.md` to save to specific file and `/pipe` to save with timestamp name. Verified file creation, content accuracy, and proper feedback messages.