### PR TITLE
feat: cumulative session stats — total tokens, time, avg tok/s

### DIFF
--- a/trashclaw.py
+++ b/trashclaw.py
@@ -113,6 +113,7 @@ APPROVED_COMMANDS: set = set()
 EXTRA_SYSTEM_PROMPT: str = ""
 LAST_ASSISTANT_RESPONSE: str = ""  # For /pipe command
 LAST_GENERATION_STATS: Dict = {}  # {tokens, seconds, tokens_per_sec} for /stats
+SESSION_STATS: Dict = {"total_tokens": 0, "total_seconds": 0.0, "total_turns": 0}  # Cumulative
 ACHIEVEMENTS_FILE = os.path.join(CONFIG_DIR, "achievements.json")
 
 # ── Trashy's Soul ──
@@ -1374,6 +1375,10 @@ def llm_request(messages: List[Dict], tools: List[Dict] = None) -> Dict:
         "seconds": elapsed,
         "tokens_per_sec": tokens_per_sec
     }
+    # Accumulate session-wide stats
+    SESSION_STATS["total_tokens"] += token_count
+    SESSION_STATS["total_seconds"] += elapsed
+    SESSION_STATS["total_turns"] += 1
     
     return {
         "choices": [{
@@ -1665,6 +1670,9 @@ def handle_slash(cmd: str) -> bool:
         print(f"  Max rounds: {MAX_TOOL_ROUNDS} | Shell approval: {'on' if APPROVE_SHELL else 'off'}")
         if APPROVED_COMMANDS:
             print(f"  Auto-approved: {', '.join(sorted(APPROVED_COMMANDS))}")
+        if SESSION_STATS["total_turns"] > 0:
+            avg_tps = SESSION_STATS["total_tokens"] / SESSION_STATS["total_seconds"] if SESSION_STATS["total_seconds"] > 0 else 0
+            print(f"  Session: {SESSION_STATS['total_tokens']:,} tokens | {SESSION_STATS['total_seconds']:.1f}s | {avg_tps:.1f} avg tok/s | {SESSION_STATS['total_turns']} turns")
 
     elif command == "/compact":
         # Keep only last 10 messages
@@ -1972,6 +1980,14 @@ def handle_slash(cmd: str) -> bool:
                 print(f"  Speed: {tps:.1f} tokens/sec")
             else:
                 print(f"  Speed: {tps}")
+            # Cumulative session stats
+            if SESSION_STATS["total_turns"] > 0:
+                avg_tps = SESSION_STATS["total_tokens"] / SESSION_STATS["total_seconds"] if SESSION_STATS["total_seconds"] > 0 else 0
+                print(f"\n  \033[1mSession Totals\033[0m")
+                print(f"  Total tokens: {SESSION_STATS['total_tokens']:,}")
+                print(f"  Total time: {SESSION_STATS['total_seconds']:.1f}s")
+                print(f"  Avg speed: {avg_tps:.1f} tokens/sec")
+                print(f"  Turns: {SESSION_STATS['total_turns']}")
             print()
 
     elif command == "/undo":


### PR DESCRIPTION
## Cumulative Session Stats

Adds session-wide tracking that accumulates across all turns:

### What's new
- `SESSION_STATS` dict tracks: total_tokens, total_seconds, total_turns
- Accumulated after each LLM response in the streaming loop
- Displayed in `/stats` (session totals section) and `/status` (one-line summary)

### /stats output now shows:
```
  Generation Stats
  Tokens: 847
  Time: 68.30s
  Speed: 12.4 tokens/sec

  Session Totals
  Total tokens: 3,241
  Total time: 245.2s
  Avg speed: 13.2 tokens/sec
  Turns: 5
```

### /status now includes:
```
  Session: 3,241 tokens | 245.2s | 13.2 avg tok/s | 5 turns
```

Per-turn stats (already implemented) remain unchanged. This adds the cumulative tracking required by the bounty.

No external dependencies.

---
Bounty: #64 (10 RTC)