### PR TITLE
Add token-per-second display and generation stats (closes #64)

### DIFF
--- a/trashclaw.py
+++ b/trashclaw.py
@@ -1442,6 +1442,9 @@ def llm_request(messages: List[Dict], tools: List[Dict] = None) -> Dict:
         "tokens_per_sec": tokens_per_sec
     }
     
+    # Display generation stats to user
+    print(f"\n\033[90m[Generated {token_count} tokens in {elapsed:.2f}s → {tokens_per_sec:.2f} tokens/sec]\033[0m")
+    
     return {
         "choices": [{
             "message": {


### PR DESCRIPTION
Implements the requested feature #64:

- Shows total token count after generation completes
- Shows total elapsed time in seconds
- Shows tokens per second generation speed
- Uses gray ANSI color to avoid distracting from main output

Ready for review!