### PR TITLE
feat: .trashclaw.toml project config with auto-loaded context files

### DIFF
--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,162 @@
+"""Tests for .trashclaw.toml / .trashclaw.json project config loading."""
+import json
+import os
+import sys
+
+import pytest
+
+# Add parent dir to path so we can import from trashclaw
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestParseTomlMinimal:
+    """Test the minimal TOML parser fallback."""
+
+    def test_string_value(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('model = "codestral"\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["model"] == "codestral"
+
+    def test_bool_true(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('auto_shell = true\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["auto_shell"] is True
+
+    def test_bool_false(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('auto_shell = false\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["auto_shell"] is False
+
+    def test_integer_value(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('max_rounds = 25\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["max_rounds"] == 25
+
+    def test_string_array(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('context_files = ["src/main.py", "README.md"]\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["context_files"] == ["src/main.py", "README.md"]
+
+    def test_empty_array(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('context_files = []\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["context_files"] == []
+
+    def test_comments_ignored(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('# This is a comment\nmodel = "gpt-4"\n# Another comment\n')
+        result = _parse_toml_minimal(str(f))
+        assert result == {"model": "gpt-4"}
+
+    def test_empty_lines_ignored(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text('\n\nmodel = "test"\n\n')
+        result = _parse_toml_minimal(str(f))
+        assert result["model"] == "test"
+
+    def test_full_config(self, tmp_path):
+        from trashclaw import _parse_toml_minimal
+        f = tmp_path / "test.toml"
+        f.write_text(
+            'context_files = ["src/main.py", "README.md"]\n'
+            'system_prompt = "You are a Rust expert"\n'
+            'model = "codestral"\n'
+            'auto_shell = true\n'
+        )
+        result = _parse_toml_minimal(str(f))
+        assert result["context_files"] == ["src/main.py", "README.md"]
+        assert result["system_prompt"] == "You are a Rust expert"
+        assert result["model"] == "codestral"
+        assert result["auto_shell"] is True
+
+
+class TestLoadConfig:
+    """Test _load_config with TOML and JSON project configs."""
+
+    def test_toml_config_loaded(self, tmp_path):
+        from trashclaw import _load_config
+        toml = tmp_path / ".trashclaw.toml"
+        toml.write_text('model = "codestral"\nauto_shell = true\n')
+        cfg = _load_config(str(tmp_path))
+        assert cfg.get("model") == "codestral"
+        assert cfg.get("auto_shell") is True
+
+    def test_json_fallback(self, tmp_path):
+        from trashclaw import _load_config
+        jf = tmp_path / ".trashclaw.json"
+        jf.write_text(json.dumps({
+            "model": "gpt-4",
+            "context_files": ["README.md"],
+            "system_prompt": "Be helpful"
+        }))
+        cfg = _load_config(str(tmp_path))
+        assert cfg.get("model") == "gpt-4"
+        assert cfg.get("context_files") == ["README.md"]
+
+    def test_toml_takes_precedence_over_json(self, tmp_path):
+        from trashclaw import _load_config
+        toml = tmp_path / ".trashclaw.toml"
+        toml.write_text('model = "codestral"\n')
+        jf = tmp_path / ".trashclaw.json"
+        jf.write_text(json.dumps({"model": "gpt-4"}))
+        cfg = _load_config(str(tmp_path))
+        assert cfg.get("model") == "codestral"
+
+    def test_no_config_returns_base(self, tmp_path):
+        from trashclaw import _load_config
+        cfg = _load_config(str(tmp_path))
+        # Should return at least an empty-ish dict (base config or empty)
+        assert isinstance(cfg, dict)
+
+
+class TestContextFilesLoading:
+    """Test that context_files from config are loaded into project instructions."""
+
+    def test_context_files_loaded(self, tmp_path, monkeypatch):
+        from trashclaw import _load_project_instructions
+        # Create project files
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "main.py").write_text("def hello(): pass")
+        (tmp_path / "README.md").write_text("# My Project")
+        # Create config
+        toml = tmp_path / ".trashclaw.toml"
+        toml.write_text('context_files = ["src/main.py", "README.md"]\n')
+        # Monkeypatch CWD
+        monkeypatch.setattr("trashclaw.CWD", str(tmp_path))
+        result = _load_project_instructions()
+        assert "def hello(): pass" in result
+        assert "# My Project" in result
+        assert "Auto-loaded Context Files" in result
+
+    def test_system_prompt_appended(self, tmp_path, monkeypatch):
+        from trashclaw import _load_project_instructions
+        toml = tmp_path / ".trashclaw.toml"
+        toml.write_text('system_prompt = "You are a Rust expert"\n')
+        monkeypatch.setattr("trashclaw.CWD", str(tmp_path))
+        result = _load_project_instructions()
+        assert "You are a Rust expert" in result
+        assert "Project System Prompt" in result
+
+    def test_missing_context_file_skipped(self, tmp_path, monkeypatch):
+        from trashclaw import _load_project_instructions
+        toml = tmp_path / ".trashclaw.toml"
+        toml.write_text('context_files = ["nonexistent.py"]\n')
+        monkeypatch.setattr("trashclaw.CWD", str(tmp_path))
+        result = _load_project_instructions()
+        # Should not crash, just skip
+        assert "nonexistent.py" not in result

--- a/trashclaw.py
+++ b/trashclaw.py
@@ -56,29 +56,79 @@ def _load_config(cwd: str = None) -> Dict:
         except Exception:
             pass
             
-    # 2. Project config from .trashclaw.toml in CWD
-    # We use a minimal TOML parser to keep zero external dependencies on Python < 3.11
+    # 2. Project config from .trashclaw.toml or .trashclaw.json in CWD
     target_cwd = cwd or os.getcwd()
-    project_config = os.path.join(target_cwd, ".trashclaw.toml")
-    if os.path.exists(project_config):
+    
+    # Try .trashclaw.toml first, then .trashclaw.json fallback
+    toml_path = os.path.join(target_cwd, ".trashclaw.toml")
+    json_path = os.path.join(target_cwd, ".trashclaw.json")
+    
+    if os.path.exists(toml_path):
         try:
-            with open(project_config, "r") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line or line.startswith("#"): continue
-                    if "=" in line:
-                        k, v = line.split("=", 1)
-                        k = k.strip()
-                        v = v.strip().strip('"').strip("'")
-                        # Basic type casting
-                        if v.lower() == "true": v = True
-                        elif v.lower() == "false": v = False
-                        elif v.isdigit(): v = int(v)
-                        cfg[k] = v
+            cfg.update(_parse_toml_minimal(toml_path))
+        except Exception:
+            pass
+    elif os.path.exists(json_path):
+        try:
+            with open(json_path, "r") as f:
+                cfg.update(json.load(f))
         except Exception:
             pass
             
     return cfg
+
+
+def _parse_toml_minimal(path: str) -> Dict:
+    """Minimal TOML parser supporting strings, bools, ints, and string arrays.
+    
+    Uses stdlib tomllib on Python 3.11+ with manual fallback for older versions.
+    Handles: key = "value", key = true/false, key = 123, key = ["a", "b"]
+    """
+    # Try stdlib tomllib first (Python 3.11+)
+    try:
+        import tomllib
+        with open(path, "rb") as f:
+            return tomllib.load(f)
+    except ImportError:
+        pass
+    
+    # Manual fallback for Python < 3.11
+    result: Dict = {}
+    with open(path, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            k = k.strip()
+            v = v.strip()
+            
+            # Array: ["item1", "item2"]
+            if v.startswith("["):
+                # Parse simple string array
+                items = []
+                inner = v.strip("[]").strip()
+                if inner:
+                    for item in inner.split(","):
+                        item = item.strip().strip('"').strip("'")
+                        if item:
+                            items.append(item)
+                result[k] = items
+            # Boolean
+            elif v.lower() == "true":
+                result[k] = True
+            elif v.lower() == "false":
+                result[k] = False
+            # Integer
+            elif v.lstrip("-").isdigit():
+                result[k] = int(v)
+            # String (quoted or bare)
+            else:
+                result[k] = v.strip('"').strip("'")
+    
+    return result
 
 def _apply_config(cfg: Dict):
     """Apply config dict to global variables."""
@@ -531,8 +581,36 @@ def _auto_compact():
 
 
 def _load_project_instructions() -> str:
-    """Load project-specific instructions from .trashclaw.md or CLAUDE.md in CWD."""
+    """Load project-specific instructions from .trashclaw.md or CLAUDE.md in CWD.
+    
+    Also loads context_files and system_prompt from .trashclaw.toml/.trashclaw.json
+    project config if present.
+    """
     result = ""
+    
+    # Load context_files from project config (auto-loaded into conversation context)
+    config = _load_config(CWD)
+    context_files = config.get("context_files", [])
+    if isinstance(context_files, list) and context_files:
+        loaded = []
+        for rel_path in context_files:
+            abs_path = os.path.join(CWD, rel_path)
+            if os.path.exists(abs_path):
+                try:
+                    with open(abs_path, "r") as f:
+                        content = f.read(4000)
+                    loaded.append(f"--- {rel_path} ---\n{content}")
+                except Exception:
+                    pass
+        if loaded:
+            result += "\n\n--- Auto-loaded Context Files ---\n" + "\n\n".join(loaded)
+    
+    # Load system_prompt from project config
+    sys_prompt = config.get("system_prompt", "")
+    if sys_prompt:
+        result += f"\n\n--- Project System Prompt ---\n{sys_prompt}"
+    
+    # Load .trashclaw.md / CLAUDE.md instructions
     for name in (".trashclaw.md", "TRASHCLAW.md", "CLAUDE.md"):
         path = os.path.join(CWD, name)
         if os.path.exists(path):


### PR DESCRIPTION
## Project Config Support

Adds `.trashclaw.toml` (and `.trashclaw.json` fallback) project config with auto-loaded context files.

### Supported fields
```toml
context_files = ["src/main.py", "README.md"]  # auto-loaded into conversation
system_prompt = "You are a Rust expert"         # appended to system prompt
model = "codestral"                              # override model name
auto_shell = true                                 # skip shell approval
```

### How it works
- Uses stdlib `tomllib` on Python 3.11+, manual parser fallback for older Python
- `.trashclaw.json` as alternative (TOML takes precedence when both exist)
- Context files are read on startup and injected into the project instructions
- System prompt is appended alongside existing .trashclaw.md support (additive)
- Existing .trashclaw.md/CLAUDE.md support unchanged

### Tests
16 tests covering:
- TOML parsing: strings, booleans, integers, string arrays, comments, empty lines
- Config loading: TOML, JSON fallback, precedence rules
- Context file auto-loading into conversation
- System prompt injection
- Graceful handling of missing files

All passing on Python 3.14.3 with pytest 9.0.2. No external dependencies.

---
Bounty: #67 (10 RTC)