### PR TITLE
docs: Add contributing link to CONTRIBUTORS.md and improve CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ trashclaw/
 
 - Open an issue for bugs or feature requests
 - Check existing issues before creating new ones
+- Join the community discussions in the Elyan Labs ecosystem
 
 ## License
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,7 @@ Thank you to all the amazing people who have contributed to TrashClaw!
 | Zby-coding | [@Zby-coding](https://github.com/Zby-coding) | CONTRIBUTORS.md |
 
 This project follows the [all-contributors](https://allcontributors.org) specification.
+
+## Contributing
+
+Want to join this list? Check out [CONTRIBUTING.md](CONTRIBUTING.md) to get started!


### PR DESCRIPTION
## Summary

Small documentation improvements to help new contributors find their way:

### Changes

1. **CONTRIBUTORS.md**: Added a "Contributing" section at the bottom with a link to CONTRIBUTING.md. This helps visitors who land on the contributors page first to understand how they can join the list.

2. **CONTRIBUTING.md**: Added a reference to community discussions in the Questions section, encouraging engagement beyond just bug reports.

### Why

- Better discoverability of contribution guidelines
- More welcoming onboarding for new contributors
- Follows documentation best practices

### Bounty Claim

This PR addresses the documentation improvement bounty in issue #69.

**Wallet**: claw-56k (RTC wallet to be provided upon merge)

---
*Part of the Elyan Labs ecosystem — contributing to better OSS documentation*