### PR TITLE
Add tests for system_info plugin

### DIFF
--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,119 +1,139 @@
 """
-Tests for system_info plugin (TrashClaw)
-Author: Nexus
+Tests for the system_info plugin.
+
+Covers: TOOL_DEF schema, run() output, detailed mode,
+internal helpers, and cross-platform edge cases.
 """
 
 import os
 import sys
 import platform
+from unittest.mock import patch, MagicMock
+
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "plugins"))
-from system_info import run, TOOL_DEF, _get_cpu_info, _get_memory_info, _get_disk_info
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "plugins"))
+
+from plugins.system_info import run, TOOL_DEF, _get_cpu_info, _get_memory_info, _get_disk_info
 
 
-# ── Tests TOOL_DEF ──
+# ── TOOL_DEF schema ──
 
-def test_tool_def_has_required_keys():
-    assert "name" in TOOL_DEF
-    assert "description" in TOOL_DEF
-    assert "parameters" in TOOL_DEF
+class TestToolDef:
+    def test_has_required_keys(self):
+        assert {"name", "description", "parameters"} <= TOOL_DEF.keys()
 
-def test_tool_def_name():
-    assert TOOL_DEF["name"] == "system_info"
+    def test_name(self):
+        assert TOOL_DEF["name"] == "system_info"
 
-def test_tool_def_description_not_empty():
-    assert len(TOOL_DEF["description"]) > 0
+    def test_description_not_empty(self):
+        assert len(TOOL_DEF["description"]) > 10
 
-def test_tool_def_parameters_schema():
-    params = TOOL_DEF["parameters"]
-    assert params["type"] == "object"
-    assert "properties" in params
-    assert "detailed" in params["properties"]
+    def test_parameters_schema(self):
+        params = TOOL_DEF["parameters"]
+        assert params["type"] == "object"
+        assert "detailed" in params["properties"]
+        assert params["properties"]["detailed"]["type"] == "boolean"
 
-
-# ── Tests run() basic ──
-
-def test_run_returns_string():
-    result = run()
-    assert isinstance(result, str)
-
-def test_run_contains_system_info():
-    result = run()
-    assert "System Information" in result
-
-def test_run_contains_os():
-    result = run()
-    assert "OS:" in result
-
-def test_run_contains_python():
-    result = run()
-    assert "Python:" in result
-
-def test_run_contains_hostname():
-    result = run()
-    assert "Hostname:" in result
-
-def test_run_contains_memory():
-    result = run()
-    assert "Memory:" in result
-
-def test_run_contains_disk():
-    result = run()
-    assert "Disk:" in result
+    def test_detailed_not_required(self):
+        assert "detailed" not in TOOL_DEF["parameters"].get("required", [])
 
 
-# ── Tests run(detailed=True) ──
+# ── run() basic ──
 
-def test_run_detailed_contains_environment():
-    result = run(detailed=True)
-    assert "Environment" in result
+class TestRunBasic:
+    def test_returns_string(self):
+        assert isinstance(run(), str)
 
-def test_run_detailed_contains_cores():
-    result = run(detailed=True)
-    assert "Cores:" in result
+    def test_not_empty(self):
+        assert len(run()) > 0
 
-def test_run_detailed_longer_than_basic():
-    basic = run(detailed=False)
-    detailed = run(detailed=True)
-    assert len(detailed) > len(basic)
+    def test_contains_section_header(self):
+        assert "System Information" in run()
 
+    def test_contains_os(self):
+        assert "OS:" in run()
 
-# ── Tests fonctions internes ──
+    def test_contains_python(self):
+        assert "Python:" in run()
 
-def test_get_cpu_info_returns_string():
-    result = _get_cpu_info()
-    assert isinstance(result, str)
-    assert len(result) > 0
+    def test_contains_hostname(self):
+        assert "Hostname:" in run()
 
-def test_get_memory_info_returns_string():
-    result = _get_memory_info()
-    assert isinstance(result, str)
+    def test_contains_memory(self):
+        assert "Memory:" in run()
 
-def test_get_memory_info_contains_gb_or_unknown():
-    result = _get_memory_info()
-    assert "GB" in result or result == "Unknown"
+    def test_contains_disk(self):
+        assert "Disk:" in run()
 
-def test_get_disk_info_returns_string():
-    result = _get_disk_info()
-    assert isinstance(result, str)
+    def test_os_matches_platform(self):
+        assert platform.system() in run()
 
-def test_get_disk_info_contains_gb_or_unknown():
-    result = _get_disk_info()
-    assert "GB" in result or result == "Unknown"
+    def test_python_version_matches(self):
+        assert platform.python_version() in run()
+
+    def test_no_detailed_section_by_default(self):
+        assert "Environment" not in run(detailed=False)
 
 
-# ── Tests edge cases ──
+# ── run(detailed=True) ──
 
-def test_run_with_unknown_kwargs():
-    result = run(detailed=False, unknown_param="test")
-    assert isinstance(result, str)
+class TestRunDetailed:
+    def test_contains_environment_section(self):
+        assert "Environment" in run(detailed=True)
 
-def test_run_os_matches_platform():
-    result = run()
-    current_os = platform.system()
-    assert current_os in result
+    def test_contains_cores(self):
+        assert "Cores:" in run(detailed=True)
 
-def test_run_python_version_matches():
-    result = run()
-    assert platform.python_version() in result
+    def test_longer_than_basic(self):
+        assert len(run(detailed=True)) > len(run(detailed=False))
+
+    def test_extra_kwargs_ignored(self):
+        result = run(detailed=False, unknown="ignored")
+        assert isinstance(result, str)
+
+
+# ── Internal helpers ──
+
+class TestGetCpuInfo:
+    def test_returns_string(self):
+        assert isinstance(_get_cpu_info(), str)
+
+    def test_not_empty(self):
+        assert len(_get_cpu_info()) > 0
+
+    def test_fallback_on_linux_error(self):
+        with patch("builtins.open", side_effect=OSError):
+            with patch("platform.system", return_value="Linux"):
+                result = _get_cpu_info()
+                assert isinstance(result, str)
+
+
+class TestGetMemoryInfo:
+    def test_returns_string(self):
+        assert isinstance(_get_memory_info(), str)
+
+    def test_contains_gb_or_unknown(self):
+        result = _get_memory_info()
+        assert "GB" in result or result == "Unknown"
+
+    def test_fallback_on_linux_error(self):
+        with patch("builtins.open", side_effect=OSError):
+            with patch("platform.system", return_value="Linux"):
+                result = _get_memory_info()
+                assert result == "Unknown"
+
+
+class TestGetDiskInfo:
+    def test_returns_string(self):
+        assert isinstance(_get_disk_info(), str)
+
+    def test_contains_gb_or_unknown(self):
+        result = _get_disk_info()
+        assert "GB" in result or result == "Unknown"
+
+    def test_fallback_on_error(self):
+        with patch("shutil.disk_usage", side_effect=OSError):
+            result = _get_disk_info()
+            assert result == "Unknown"

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,119 @@
+"""
+Tests for system_info plugin (TrashClaw)
+Author: Nexus
+"""
+
+import os
+import sys
+import platform
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "plugins"))
+from system_info import run, TOOL_DEF, _get_cpu_info, _get_memory_info, _get_disk_info
+
+
+# ── Tests TOOL_DEF ──
+
+def test_tool_def_has_required_keys():
+    assert "name" in TOOL_DEF
+    assert "description" in TOOL_DEF
+    assert "parameters" in TOOL_DEF
+
+def test_tool_def_name():
+    assert TOOL_DEF["name"] == "system_info"
+
+def test_tool_def_description_not_empty():
+    assert len(TOOL_DEF["description"]) > 0
+
+def test_tool_def_parameters_schema():
+    params = TOOL_DEF["parameters"]
+    assert params["type"] == "object"
+    assert "properties" in params
+    assert "detailed" in params["properties"]
+
+
+# ── Tests run() basic ──
+
+def test_run_returns_string():
+    result = run()
+    assert isinstance(result, str)
+
+def test_run_contains_system_info():
+    result = run()
+    assert "System Information" in result
+
+def test_run_contains_os():
+    result = run()
+    assert "OS:" in result
+
+def test_run_contains_python():
+    result = run()
+    assert "Python:" in result
+
+def test_run_contains_hostname():
+    result = run()
+    assert "Hostname:" in result
+
+def test_run_contains_memory():
+    result = run()
+    assert "Memory:" in result
+
+def test_run_contains_disk():
+    result = run()
+    assert "Disk:" in result
+
+
+# ── Tests run(detailed=True) ──
+
+def test_run_detailed_contains_environment():
+    result = run(detailed=True)
+    assert "Environment" in result
+
+def test_run_detailed_contains_cores():
+    result = run(detailed=True)
+    assert "Cores:" in result
+
+def test_run_detailed_longer_than_basic():
+    basic = run(detailed=False)
+    detailed = run(detailed=True)
+    assert len(detailed) > len(basic)
+
+
+# ── Tests fonctions internes ──
+
+def test_get_cpu_info_returns_string():
+    result = _get_cpu_info()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+def test_get_memory_info_returns_string():
+    result = _get_memory_info()
+    assert isinstance(result, str)
+
+def test_get_memory_info_contains_gb_or_unknown():
+    result = _get_memory_info()
+    assert "GB" in result or result == "Unknown"
+
+def test_get_disk_info_returns_string():
+    result = _get_disk_info()
+    assert isinstance(result, str)
+
+def test_get_disk_info_contains_gb_or_unknown():
+    result = _get_disk_info()
+    assert "GB" in result or result == "Unknown"
+
+
+# ── Tests edge cases ──
+
+def test_run_with_unknown_kwargs():
+    result = run(detailed=False, unknown_param="test")
+    assert isinstance(result, str)
+
+def test_run_os_matches_platform():
+    result = run()
+    current_os = platform.system()
+    assert current_os in result
+
+def test_run_python_version_matches():
+    result = run()
+    assert platform.python_version() in result


### PR DESCRIPTION
Closes #133

Adds test coverage for the `system_info` plugin.

## What's covered
- TOOL_DEF schema validation
- run() basic output
- run(detailed=True) extended output
- Internal helpers with error handling mocks
- Cross-platform edge cases

## Results
All tests passing with Python 3.7+ stdlib only (unittest.mock)