### PR TITLE
Fix outdated User-Agent version in tool_fetch_url

### DIFF
--- a/trashclaw.py
+++ b/trashclaw.py
@@ -986,7 +986,7 @@ def tool_list_dir(path: str = None) -> str:
 
 def tool_fetch_url(url: str) -> str:
     try:
-        req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) TrashClaw/0.2'})
+        req = urllib.request.Request(url, headers={'User-Agent': f'Mozilla/5.0 (Windows NT 10.0; Win64; x64) TrashClaw/{VERSION}'})
         with urllib.request.urlopen(req, timeout=30) as response:
             html = response.read().decode('utf-8', errors='ignore')
             


### PR DESCRIPTION
## Summary
Updated the `User-Agent` string in `tool_fetch_url` to use the `VERSION` constant instead of a hardcoded "0.2". This ensures the User-Agent always reflects the current version of TrashClaw.

## Test plan
1.  Verified that `tool_fetch_url` sends the correct User-Agent using `trashclaw.VERSION`.
2.  Ran existing tests to ensure no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)