### PR TITLE
feat: add 3 new tools — word_count, timestamp, regex_test (bounty #132)

### DIFF
--- a/plugins/regex_test.py
+++ b/plugins/regex_test.py
@@ -1,0 +1,91 @@
+"""
+Regex Test Plugin for TrashClaw
+
+Test regular expressions against input text. Shows matches, groups, and positions.
+
+Plugin contract:
+  TOOL_DEF = dict with name, description, parameters (OpenAI function schema)
+  run(**kwargs) -> str
+"""
+
+import re
+
+TOOL_DEF = {
+    "name": "regex_test",
+    "description": "Test a regular expression pattern against input text. Shows all matches with positions and groups.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "pattern": {
+                "type": "string",
+                "description": "Regular expression pattern to test"
+            },
+            "text": {
+                "type": "string",
+                "description": "Text to match against"
+            },
+            "flags": {
+                "type": "string",
+                "description": "Regex flags: i (ignore case), m (multiline), s (dotall), x (verbose). Combine: 'im'"
+            }
+        },
+        "required": ["pattern", "text"]
+    }
+}
+
+
+def _parse_flags(flags_str: str) -> int:
+    flag_map = {
+        "i": re.IGNORECASE,
+        "m": re.MULTILINE,
+        "s": re.DOTALL,
+        "x": re.VERBOSE,
+    }
+    result = 0
+    for ch in flags_str.lower():
+        if ch in flag_map:
+            result |= flag_map[ch]
+    return result
+
+
+def run(pattern: str = "", text: str = "", flags: str = "", **kwargs) -> str:
+    if not pattern:
+        return "Error: 'pattern' is required."
+    if not text:
+        return "Error: 'text' is required."
+
+    try:
+        compiled = re.compile(pattern, _parse_flags(flags))
+    except re.error as e:
+        return f"Regex compile error: {e}"
+
+    matches = list(compiled.finditer(text))
+
+    if not matches:
+        return f"Pattern: /{pattern}/{''.join(sorted(flags.lower()))}\nNo matches found."
+
+    lines = [
+        f"Pattern: /{pattern}/{''.join(sorted(flags.lower()))}",
+        f"Matches: {len(matches)}",
+        "",
+    ]
+
+    for i, m in enumerate(matches[:50]):  # cap at 50 matches
+        line = f"  [{i}] \"{m.group()}\" at {m.start()}-{m.end()}"
+        if m.groups():
+            groups = ", ".join(
+                f"${j+1}=\"{g}\"" for j, g in enumerate(m.groups()) if g is not None
+            )
+            line += f"  groups: {groups}"
+        if m.groupdict():
+            named = ", ".join(
+                f"{k}=\"{v}\"" for k, v in m.groupdict().items() if v is not None
+            )
+            if named:
+                line += f"  named: {named}"
+        lines.append(line)
+
+    if len(matches) > 50:
+        lines.append(f"  ... and {len(matches) - 50} more matches")
+
+    return "\n".join(lines)

--- a/plugins/timestamp.py
+++ b/plugins/timestamp.py
@@ -1,0 +1,97 @@
+"""
+Timestamp Plugin for TrashClaw
+
+Convert between Unix timestamps and human-readable dates. Show current time.
+
+Plugin contract:
+  TOOL_DEF = dict with name, description, parameters (OpenAI function schema)
+  run(**kwargs) -> str
+"""
+
+import time
+from datetime import datetime, timezone
+
+TOOL_DEF = {
+    "name": "timestamp",
+    "description": "Convert between Unix timestamps and human-readable dates, or show current time.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "unix": {
+                "type": "number",
+                "description": "Unix timestamp (seconds) to convert to human date"
+            },
+            "date": {
+                "type": "string",
+                "description": "Human date string (ISO 8601, e.g. '2026-03-25T12:00:00') to convert to Unix"
+            },
+            "now": {
+                "type": "boolean",
+                "description": "If true, show current time in multiple formats"
+            }
+        },
+        "required": []
+    }
+}
+
+
+def run(unix: float = None, date: str = "", now: bool = False, **kwargs) -> str:
+    results = []
+
+    if now or (unix is None and not date):
+        ts = time.time()
+        dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+        local_dt = datetime.fromtimestamp(ts)
+        results.append(
+            f"Current Time:\n"
+            f"  Unix:  {int(ts)}\n"
+            f"  UTC:   {dt.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+            f"  Local: {local_dt.strftime('%Y-%m-%d %H:%M:%S')}"
+        )
+
+    if unix is not None:
+        try:
+            dt_utc = datetime.fromtimestamp(float(unix), tz=timezone.utc)
+            dt_local = datetime.fromtimestamp(float(unix))
+            results.append(
+                f"Unix {int(unix)} =\n"
+                f"  UTC:   {dt_utc.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
+                f"  Local: {dt_local.strftime('%Y-%m-%d %H:%M:%S')}\n"
+                f"  ISO:   {dt_utc.isoformat()}"
+            )
+        except (ValueError, OSError, OverflowError) as e:
+            results.append(f"Error converting unix timestamp: {e}")
+
+    if date:
+        formats = [
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M:%SZ",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d",
+            "%d/%m/%Y %H:%M:%S",
+            "%d/%m/%Y",
+            "%m/%d/%Y",
+        ]
+        parsed = None
+        for fmt in formats:
+            try:
+                parsed = datetime.strptime(date.strip(), fmt)
+                break
+            except ValueError:
+                continue
+
+        if parsed:
+            ts = int(parsed.timestamp())
+            results.append(
+                f"'{date}' =\n"
+                f"  Unix:    {ts}\n"
+                f"  Parsed:  {parsed.strftime('%Y-%m-%d %H:%M:%S')}\n"
+                f"  ISO:     {parsed.isoformat()}"
+            )
+        else:
+            results.append(
+                f"Error: could not parse '{date}'. "
+                f"Supported formats: ISO 8601, YYYY-MM-DD, DD/MM/YYYY, MM/DD/YYYY"
+            )
+
+    return "\n\n".join(results) if results else "Error: provide 'unix', 'date', or set 'now' to true."

--- a/plugins/word_count.py
+++ b/plugins/word_count.py
@@ -1,0 +1,68 @@
+"""
+Word Count Plugin for TrashClaw
+
+Count words, characters, lines, sentences, and paragraphs in text or a file.
+
+Plugin contract:
+  TOOL_DEF = dict with name, description, parameters (OpenAI function schema)
+  run(**kwargs) -> str
+"""
+
+import os
+import re
+
+TOOL_DEF = {
+    "name": "word_count",
+    "description": "Count words, characters, lines, sentences, and paragraphs in text or a file.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {
+                "type": "string",
+                "description": "Text to analyze"
+            },
+            "file": {
+                "type": "string",
+                "description": "Path to file to analyze (optional, used instead of text)"
+            }
+        },
+        "required": []
+    }
+}
+
+
+def _count(text: str) -> dict:
+    lines = text.split("\n")
+    words = text.split()
+    sentences = [s.strip() for s in re.split(r'[.!?]+', text) if s.strip()]
+    paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
+    return {
+        "characters": len(text),
+        "characters_no_spaces": len(text.replace(" ", "").replace("\t", "")),
+        "words": len(words),
+        "lines": len(lines),
+        "sentences": len(sentences),
+        "paragraphs": len(paragraphs),
+    }
+
+
+def run(text: str = "", file: str = "", **kwargs) -> str:
+    if file:
+        if not os.path.exists(file):
+            return f"Error: file not found: {file}"
+        try:
+            with open(file, "r", encoding="utf-8", errors="replace") as f:
+                text = f.read()
+        except Exception as e:
+            return f"Error reading file: {e}"
+
+    if not text:
+        return "Error: provide 'text' or 'file' to analyze."
+
+    stats = _count(text)
+    source = f" ({file})" if file else ""
+    lines = [f"Word Count{source}:"]
+    for key, val in stats.items():
+        label = key.replace("_", " ").title()
+        lines.append(f"  {label}: {val:,}")
+    return "\n".join(lines)

--- a/tests/test_regex_test.py
+++ b/tests/test_regex_test.py
@@ -1,0 +1,40 @@
+"""Tests for the regex_test plugin."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "plugins"))
+from regex_test import run
+
+
+def test_basic_match():
+    result = run(pattern=r"\d+", text="abc 123 def 456")
+    assert "Matches: 2" in result
+    assert '"123"' in result
+    assert '"456"' in result
+
+
+def test_no_match():
+    result = run(pattern=r"\d+", text="no numbers here")
+    assert "No matches" in result
+
+
+def test_groups():
+    result = run(pattern=r"(\w+)@(\w+)", text="user@host")
+    assert '$1="user"' in result
+    assert '$2="host"' in result
+
+
+def test_flags_ignore_case():
+    result = run(pattern="hello", text="HELLO world", flags="i")
+    assert "Matches: 1" in result
+
+
+def test_invalid_pattern():
+    result = run(pattern="[unclosed", text="test")
+    assert "error" in result.lower()
+
+
+def test_missing_args():
+    result = run()
+    assert "Error" in result

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,0 +1,34 @@
+"""Tests for the timestamp plugin."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "plugins"))
+from timestamp import run
+
+
+def test_now():
+    result = run(now=True)
+    assert "Unix:" in result
+    assert "UTC:" in result
+
+
+def test_unix_to_date():
+    result = run(unix=0)
+    assert "1970" in result
+
+
+def test_date_to_unix():
+    result = run(date="2026-03-25T12:00:00")
+    assert "Unix:" in result
+    assert "2026-03-25" in result
+
+
+def test_invalid_date():
+    result = run(date="not-a-date")
+    assert "Error" in result or "could not parse" in result
+
+
+def test_default_shows_now():
+    result = run()
+    assert "Current Time" in result

--- a/tests/test_word_count.py
+++ b/tests/test_word_count.py
@@ -1,0 +1,40 @@
+"""Tests for the word_count plugin."""
+
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "plugins"))
+from word_count import run
+
+
+def test_basic_text():
+    result = run(text="Hello world. This is a test.")
+    assert "Words: 6" in result
+    assert "Sentences: 2" in result
+
+
+def test_multiline():
+    result = run(text="Line one\nLine two\nLine three")
+    assert "Lines: 3" in result
+    assert "Words: 6" in result
+
+
+def test_file_input():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        f.write("One two three\nFour five")
+        f.flush()
+        result = run(file=f.name)
+    os.unlink(f.name)
+    assert "Words: 5" in result
+    assert "Lines: 2" in result
+
+
+def test_empty_input():
+    result = run()
+    assert "Error" in result
+
+
+def test_missing_file():
+    result = run(file="/nonexistent/path.txt")
+    assert "Error" in result


### PR DESCRIPTION
## Bounty #132 — Add New Tools (3 × 2 RTC = 6 RTC)

### Tools Added

1. **word_count** — Count words, characters, lines, sentences, paragraphs in text or file
2. **timestamp** — Convert Unix ↔ human dates, show current time (ISO 8601, DD/MM/YYYY, etc.)
3. **regex_test** — Test regex patterns with match positions, captured groups, and flags (i/m/s/x)

### Tests
16 pytest tests (5 + 5 + 6), all passing ✅

### Plugin Contract
All tools follow the existing pattern: `TOOL_DEF` dict + `run(**kwargs)` function. Pure stdlib, zero dependencies.

Closes #132