### PR TITLE
docs: improve CONTRIBUTING.md clarity - add comment about YOUR_USERNAME placeholder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Thank you for your interest in contributing to TrashClaw! This guide will help y
 ```bash
 # Clone the repository
 git clone https://github.com/YOUR_USERNAME/trashclaw.git
+# Replace YOUR_USERNAME with your actual GitHub username
 cd trashclaw
 
 # Start your local LLM server (example with Ollama)


### PR DESCRIPTION
This PR adds a clarifying comment to CONTRIBUTING.md about the `YOUR_USERNAME` placeholder in the repository URL example.

The comment explains that users should replace `YOUR_USERNAME` with their actual GitHub username when cloning the repository, which should help reduce confusion for new contributors.