### PR TITLE
fix: respect cwd for /pipe output

### DIFF
--- a/tests/test_pipe.py
+++ b/tests/test_pipe.py
@@ -1,0 +1,47 @@
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import trashclaw
+
+
+@pytest.fixture(autouse=True)
+def reset_pipe_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(trashclaw, "LAST_ASSISTANT_RESPONSE", "hello from trashclaw")
+    monkeypatch.setattr(trashclaw, "CWD", str(tmp_path))
+
+
+def test_pipe_without_filename_saves_in_cwd(capsys, tmp_path):
+    trashclaw.handle_slash("/pipe")
+    captured = capsys.readouterr().out
+
+    files = list(tmp_path.iterdir())
+    assert len(files) == 1
+    saved = files[0]
+    assert saved.name.startswith("response_")
+    assert saved.suffix == ".md"
+    assert saved.read_text(encoding="utf-8") == "hello from trashclaw"
+    assert str(saved) in captured
+    assert saved.name in captured
+
+
+def test_pipe_with_relative_filename_uses_cwd(capsys, tmp_path):
+    trashclaw.handle_slash("/pipe notes/output.md")
+    captured = capsys.readouterr().out
+
+    saved = tmp_path / "notes" / "output.md"
+    assert saved.exists()
+    assert saved.read_text(encoding="utf-8") == "hello from trashclaw"
+    assert str(saved) in captured
+    assert "notes/output.md" in captured.replace("\\", "/")
+
+
+def test_pipe_without_response_prints_error(capsys, monkeypatch):
+    monkeypatch.setattr(trashclaw, "LAST_ASSISTANT_RESPONSE", "")
+    trashclaw.handle_slash("/pipe")
+    captured = capsys.readouterr().out
+    assert "No assistant message found" in captured

--- a/trashclaw.py
+++ b/trashclaw.py
@@ -2049,32 +2049,34 @@ def handle_slash(cmd: str) -> bool:
             # Generate filename if not provided
             if not arg:
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                filename = f"response_{timestamp}.md"
+                filename = os.path.join(CWD, f"response_{timestamp}.md")
             else:
-                filename = arg
-            
+                filename = _resolve_path(arg)
+
             # Ensure output directory exists
-            output_dir = os.path.dirname(filename) or '.'
+            output_dir = os.path.dirname(filename) or CWD
             os.makedirs(output_dir, exist_ok=True)
-            
+
             # Save to file
             try:
                 with open(filename, 'w', encoding='utf-8') as f:
                     f.write(LAST_ASSISTANT_RESPONSE)
-                
+
                 # Get file size
                 file_size = os.path.getsize(filename)
-                # Format file size
+                display_size = float(file_size)
+                file_size_str = f"{display_size:.2f} TB"
                 for unit in ['B', 'KB', 'MB', 'GB']:
-                    if file_size < 1024.0:
-                        file_size_str = f"{file_size:.2f} {unit}"
+                    if display_size < 1024.0:
+                        file_size_str = f"{display_size:.2f} {unit}"
                         break
-                    file_size /= 1024.0
-                
+                    display_size /= 1024.0
+
                 # Get absolute path
                 abs_path = os.path.abspath(filename)
-                
-                print(f"  ✅ Saved to `{filename}`")
+                rel_display = os.path.relpath(abs_path, CWD)
+
+                print(f"  ✅ Saved to `{rel_display}`")
                 print(f"  📁 Path: `{abs_path}`")
                 print(f"  📊 Size: `{file_size_str}`")
             except Exception as e:


### PR DESCRIPTION
## Summary
- make  write default output inside the current working directory
- resolve relative output paths against  instead of the launcher directory
- add regression tests for default, relative-path, and empty-response cases

## Testing
- ............                                                             [100%]
12 passed in 0.01s
- 

Fixes #66