### PR TITLE
feat: add read-only audit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See `plugins/example_weather.py` for a complete example.
 - **Retry logic**: Auto-retries on LLM connection failure
 - **Undo**: `/undo` rolls back file changes
 - **Non-interactive**: `--exec "prompt"` or pipe via stdin
+- **Read-only audits**: `--read-only` or `TRASHCLAW_READONLY=1` blocks write, shell, commit, and clipboard-copy tools for safe first runs
 - **Achievements**: 10 milestones tracked persistently
 - **Hardware detection**: Detects and displays system info — supports vintage hardware (PowerPC G4/G5, IBM POWER8, Mac Pro Trashcan)
 
@@ -183,6 +184,7 @@ TRASHCLAW_URL=http://localhost:1234/v1 python3 trashclaw.py
 | `TRASHCLAW_MAX_ROUNDS` | `15` | Max tool rounds per task |
 | `TRASHCLAW_MAX_CONTEXT` | `80` | Max conversation messages |
 | `TRASHCLAW_AUTO_SHELL` | `0` | Set `1` to auto-approve commands |
+| `TRASHCLAW_READONLY` | `0` | Set `1` to hide and block side-effecting tools |
 
 ### Config File
 
@@ -194,6 +196,7 @@ TRASHCLAW_URL=http://localhost:1234/v1 python3 trashclaw.py
 python3 trashclaw.py --cwd ~/project     # Set working directory
 python3 trashclaw.py --url http://...     # Set LLM endpoint
 python3 trashclaw.py --auto-shell         # Skip command approval
+python3 trashclaw.py --read-only          # Audit without file writes or shell commands
 python3 trashclaw.py --system "You are a Rust expert"  # Custom instructions
 python3 trashclaw.py -e "fix the linting errors"       # One-shot mode
 echo "deploy to staging" | python3 trashclaw.py         # Pipe mode

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,7 @@
 """Tests for new TrashClaw plugins: markdown_table, text_diff, timer."""
 import sys
 import os
+import unittest
 import pytest
 
 # Add project root to path

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -262,6 +262,33 @@ class TestGitCommit:
 
 # ── tab completion ──
 
+class TestReadOnlyMode:
+    def test_available_tools_hides_side_effecting_tools(self, monkeypatch):
+        monkeypatch.setattr(trashclaw, "READ_ONLY_MODE", True)
+        names = {tool["function"]["name"] for tool in trashclaw._available_tools()}
+        assert "read_file" in names
+        assert "search_files" in names
+        assert "git_diff" in names
+        assert "write_file" not in names
+        assert "edit_file" not in names
+        assert "patch_file" not in names
+        assert "run_command" not in names
+        assert "git_commit" not in names
+
+    def test_read_only_blocks_write_and_shell(self, monkeypatch):
+        monkeypatch.setattr(trashclaw, "READ_ONLY_MODE", True)
+        assert trashclaw._read_only_blocked("write_file", {})
+        assert trashclaw._read_only_blocked("run_command", {})
+        assert trashclaw._read_only_blocked("git_commit", {})
+        assert not trashclaw._read_only_blocked("read_file", {})
+        assert not trashclaw._read_only_blocked("git_status", {})
+
+    def test_read_only_allows_only_clipboard_paste(self, monkeypatch):
+        monkeypatch.setattr(trashclaw, "READ_ONLY_MODE", True)
+        assert not trashclaw._read_only_blocked("clipboard", {"action": "paste"})
+        assert trashclaw._read_only_blocked("clipboard", {"action": "copy"})
+
+
 class TestTabCompletion:
     def test_setup_tab_completion_runs(self):
         try:

--- a/tests/test_untested_tool.py
+++ b/tests/test_untested_tool.py
@@ -5,6 +5,7 @@ Tests for hash, base64, and json_format plugins.
 import sys
 import os
 import json
+import unittest
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/trashclaw.py
+++ b/trashclaw.py
@@ -114,7 +114,7 @@ def _load_config(cwd: str = None) -> Dict:
 def _apply_config(cfg: Dict):
     """Apply config dict to global variables."""
     global LLAMA_URL, MODEL_NAME, MAX_TOOL_ROUNDS, MAX_CONTEXT_MESSAGES
-    global AUTO_COMPACT_THRESHOLD, APPROVE_SHELL, EXTRA_SYSTEM_PROMPT
+    global AUTO_COMPACT_THRESHOLD, APPROVE_SHELL, EXTRA_SYSTEM_PROMPT, READ_ONLY_MODE
     
     def _c(key: str, env_key: str, default: Any) -> Any:
         val = os.environ.get(env_key, cfg.get(key, default))
@@ -129,6 +129,7 @@ def _apply_config(cfg: Dict):
     MAX_CONTEXT_MESSAGES = _c("max_context", "TRASHCLAW_MAX_CONTEXT", 80)
     AUTO_COMPACT_THRESHOLD = MAX_CONTEXT_MESSAGES + 20
     APPROVE_SHELL = _c("auto_shell", "TRASHCLAW_AUTO_SHELL", "0") != "1"
+    READ_ONLY_MODE = str(_c("read_only", "TRASHCLAW_READONLY", "0")).lower() in ("1", "true", "yes", "on")
 
     # Project-level system prompt override from .trashclaw.toml
     if "system_prompt" in cfg and cfg["system_prompt"]:
@@ -184,6 +185,7 @@ HISTORY: List[Dict] = []
 UNDO_STACK: List[Dict] = []  # [{path, content_before, action}]
 APPROVED_COMMANDS: set = set()
 EXTRA_SYSTEM_PROMPT: str = ""
+READ_ONLY_MODE: bool = globals().get("READ_ONLY_MODE", False)
 LAST_ASSISTANT_RESPONSE: str = ""  # For /pipe command
 LAST_GENERATION_STATS: Dict = {}  # {tokens, seconds, tokens_per_sec} for /stats
 SESSION_STATS: Dict = {"total_tokens": 0, "total_seconds": 0.0, "turns": 0}  # Cumulative session stats
@@ -324,6 +326,45 @@ def _track_tool(tool_name: str):
     _save_achievements(ACHIEVEMENTS)
 CWD = os.getcwd()
 _INTERRUPTED = False
+
+READ_ONLY_ALLOWED_TOOLS = {
+    "read_file", "search_files", "find_files", "list_dir", "fetch_url",
+    "think", "git_status", "git_diff", "view_image", "word_count",
+    "base64", "clipboard",
+}
+
+def _available_tools() -> List[Dict]:
+    """Return the tool schema list visible to the model for the current mode."""
+    if not READ_ONLY_MODE:
+        return TOOLS
+    allowed = []
+    for tool in TOOLS:
+        name = tool.get("function", {}).get("name", "")
+        if name in READ_ONLY_ALLOWED_TOOLS and name not in READ_ONLY_BLOCKED_TOOLS:
+            allowed.append(tool)
+    return allowed
+READ_ONLY_BLOCKED_TOOLS = {
+    "write_file", "edit_file", "patch_file", "run_command", "git_commit",
+}
+
+def _read_only_blocked(tool_name: str, args: Dict = None) -> bool:
+    """Return true when a tool call would create side effects in read-only mode."""
+    if not READ_ONLY_MODE:
+        return False
+    args = args or {}
+    if tool_name in READ_ONLY_BLOCKED_TOOLS:
+        return True
+    if tool_name == "clipboard" and args.get("action", "paste") != "paste":
+        return True
+    return tool_name not in READ_ONLY_ALLOWED_TOOLS
+
+def _read_only_message(tool_name: str) -> str:
+    return (
+        f"Read-only mode blocked tool '{tool_name}'. "
+        "Allowed tools: read_file, search_files, find_files, list_dir, "
+        "fetch_url, think, git_status, git_diff, view_image, word_count, "
+        "base64, and clipboard paste."
+    )
 
 # ── Tool Definitions ──
 
@@ -1403,6 +1444,9 @@ def _load_plugins():
             name = tool_def.get("name", fname[:-3])
             if name in TOOL_DISPATCH:
                 continue  # Don't override built-in tools
+            if READ_ONLY_MODE:
+                print(f"  \033[90m[plugin skipped: read-only]\033[0m {name}")
+                continue
 
             # Register the tool
             TOOLS.append({
@@ -1839,6 +1883,13 @@ def _agent_loop(round_limit: int):
         )
         if EXTRA_SYSTEM_PROMPT:
             sys_prompt += f"\n\n--- Custom Instructions ---\n{EXTRA_SYSTEM_PROMPT}"
+        if READ_ONLY_MODE:
+            sys_prompt += (
+                "\n\n--- Read-only mode ---\n"
+                "You are auditing only. Do not write files, patch files, run shell commands, "
+                "commit changes, or copy to the clipboard. Use read/search/list/fetch/git diff "
+                "tools and propose a patch plan instead."
+            )
         messages = [{"role": "system", "content": sys_prompt}]
         # Keep recent context within bounds
         messages.extend(HISTORY[-MAX_CONTEXT_MESSAGES:])
@@ -1848,7 +1899,7 @@ def _agent_loop(round_limit: int):
         print(f"{indicator}\033[90mthinking...\033[0m", end="", flush=True)
 
         # Call LLM (with retry on connection failure)
-        response = llm_request_with_retry(messages, tools=TOOLS)
+        response = llm_request_with_retry(messages, tools=_available_tools())
 
         # Clear thinking indicator
         print(f"\r{' ' * 60}\r", end="")
@@ -1961,8 +2012,11 @@ def _agent_loop(round_limit: int):
             handler = TOOL_DISPATCH.get(tool_name)
             if handler:
                 try:
-                    result = handler(args)
-                    _track_tool(tool_name)
+                    if _read_only_blocked(tool_name, args):
+                        result = _read_only_message(tool_name)
+                    else:
+                        result = handler(args)
+                        _track_tool(tool_name)
                 except Exception as e:
                     result = f"Error executing {tool_name}: {e}\n{traceback.format_exc()}"
             else:
@@ -2586,6 +2640,7 @@ def handle_slash(cmd: str) -> bool:
   --cwd <dir>    Set working directory
   --url <url>    Set LLM server URL
   --auto-shell   Skip shell command approval
+  --read-only    Audit mode: hide and block write/shell/commit/clipboard-copy tools
   -e, --exec "prompt"  Run one prompt and exit (non-interactive)
   --system "text" Inject custom instructions into system prompt
   --watch "*.py" "run tests"  Watch files, run prompt on change
@@ -2597,6 +2652,7 @@ def handle_slash(cmd: str) -> bool:
   TRASHCLAW_MAX_ROUNDS  Max tool rounds per turn (default: 15)
   TRASHCLAW_MAX_CONTEXT Max conversation messages (default: 80)
   TRASHCLAW_AUTO_SHELL  Set to 1 to skip shell approval
+  TRASHCLAW_READONLY    Set to 1 to block side-effecting tools
 
   \033[1mFeatures\033[0m
   Tab completion for slash commands and file paths.
@@ -2637,6 +2693,8 @@ def banner():
 """)
     print(f"    \033[1mElyan Labs\033[0m | v{VERSION} | \033[90m\"{quote}\"\033[0m")
     print(f"    Running on: \033[36m{hw_label}\033[0m | Model: {MODEL_NAME} | CWD: {CWD}")
+    if READ_ONLY_MODE:
+        print("    Mode: \033[33mread-only\033[0m | write/shell/commit tools blocked")
     if achievements_count > 0:
         print(f"    Achievements: {achievements_count}/{total_achievements} unlocked")
     print(f"    Type /help for commands, /about for the manifesto.\n")
@@ -2709,6 +2767,8 @@ def main():
             globals()["LLAMA_URL"] = args[i].split("=", 1)[1]; i += 1
         elif args[i] == "--auto-shell":
             globals()["APPROVE_SHELL"] = False; i += 1
+        elif args[i] == "--read-only":
+            globals()["READ_ONLY_MODE"] = True; i += 1
         elif args[i] in ("-e", "--exec") and i + 1 < len(args):
             one_shot = args[i + 1]; i += 2
         elif args[i] == "--system" and i + 1 < len(args):


### PR DESCRIPTION
## Summary

- Adds `TRASHCLAW_READONLY=1` and `--read-only` for safe first-run audits.
- Hides side-effecting tools from the model in read-only mode and blocks them again at dispatch time.
- Allows read/search/list/fetch/git diff style inspection tools, while blocking file writes, patches, shell commands, commits, plugin tools, and clipboard copy.
- Documents the new mode and adds focused tests for tool filtering/blocking.
- Adds missing `unittest` imports in two existing test modules so full-suite collection can proceed.

Fixes #195.

## Validation

- `py -m py_compile trashclaw.py`
- `git show --check --oneline HEAD`
- `py -m pytest -q tests\test_tools.py::TestReadOnlyMode tests\test_tools.py::TestWriteFile tests\test_tools.py::TestGitCommit` - 9 passed
- `py -m pytest -q tests\test_tools.py::TestReadOnlyMode tests\test_tools.py::TestWriteFile tests\test_tools.py::TestGitCommit tests\test_plugins.py::TestUntestedTool tests\test_untested_tool.py::TestUntestedTool` - 11 passed
- Manual stdlib assertions for read-only tool visibility, blocked write/shell/commit tools, clipboard paste allowed, clipboard copy blocked, and `TRASHCLAW_READONLY=1` config loading.
- Full suite after installing pytest locally: `320 passed, 7 failed`. The remaining failures appear unrelated to this change: DNS/port behavior on this environment, macOS GPU mock expectations, Windows CPU info, and an existing word-count expectation.

## Payout

If accepted/merged under the Scottcjn RTC bounty flow, payout address: `0x255969B3265958Dc0B8db1082843d0e7E82cb62d`